### PR TITLE
Update repository URL for Flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: black
         args: [--line-length=80]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: "3.8.4"
     hooks:
       - id: flake8


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos